### PR TITLE
Return TypedArrays sharing the original buffer when possible.

### DIFF
--- a/src/bytestream.js
+++ b/src/bytestream.js
@@ -18,20 +18,12 @@ ByteStream.prototype.peekByte = function(){
 
 // read an array of bytes
 ByteStream.prototype.readBytes = function(n){
-	var bytes = new Array(n);
-	for(var i=0; i<n; i++){
-		bytes[i] = this.readByte();
-	}
-	return bytes;
+	return this.data.subarray(this.pos, this.pos += n);
 };
 
 // peek at an array of bytes without updating the stream position
 ByteStream.prototype.peekBytes = function(n){
-	var bytes = new Array(n);
-	for(var i=0; i<n; i++){
-		bytes[i] = this.data[this.pos + i];
-	}
-	return bytes;
+	return this.data.subarray(this.pos, this.pos + n);
 };
 
 // read a string from a byte set


### PR DESCRIPTION
This is a backwards incompatible change, and I considered having new methods for this. But ultimately decided it would be better for users of the library to have to consciously decide to actually copy the data.

Old behaviour is neatly emulated with something like this: `Array.from(stream.readBytes(1024))`

This change (along with a compatibility change in the gif library) results in a 60x decoding performance improvement for this gif according to chrome dev tools (which probably skews things): https://i.imgur.com/aA1ZrWR.gif