### PR TITLE
Null checks to avoid infinte recursion

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,12 +33,16 @@ export const loop = (schema, continueFunc) => (
   parse
 ) => {
   const arr = []
+  let lastStreamPos = stream.pos;
   while (continueFunc(stream, result, parent)) {
     const newParent = {}
     parse(stream, schema, result, newParent)
     // cases when whole file is parsed but no termination is there and stream position is not getting updated as well
     // it falls into infinite recursion, null check to avoid the same
-    if(Object.keys(newParent).length === 0) break;
+    if(stream.pos === lastStreamPos) {
+      break
+    }
+    lastStreamPos = stream.pos
     arr.push(newParent)
   }
   return arr

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,9 @@ export const loop = (schema, continueFunc) => (
   while (continueFunc(stream, result, parent)) {
     const newParent = {}
     parse(stream, schema, result, newParent)
+    // cases when whole file is parsed but no termination is there and stream position is not getting updated as well
+    // it falls into infinite recursion, null check to avoid the same
+    if(Object.keys(newParent).length === 0) break;
     arr.push(newParent)
   }
   return arr

--- a/src/schemas/gif.js
+++ b/src/schemas/gif.js
@@ -22,6 +22,9 @@ var subBlocksSchema = {
       size !== terminator;
       size = readByte()(stream)
     ) {
+      // size becomes undefined for some case when file is corrupted and  terminator is not proper 
+      // null check to avoid recursion
+      if(!size) break;
       // catch corrupted files with no terminator
       if (stream.pos + size >= streamSize) {
         const availableSize = streamSize - stream.pos


### PR DESCRIPTION
Fix for https://github.com/matt-way/jsBinarySchemaParser/issues/7

Parser use to go to infinite recursion for a couple of GIF files

Added null condition in the GIF schema and loop function definitions.

corrupted GIFs-> 
![problemGif](https://user-images.githubusercontent.com/22216430/138494392-d7ae30fc-51b6-4c3f-8905-6c9c532f5a7b.gif)
![concave](https://user-images.githubusercontent.com/22216430/138494424-41e34358-0b1f-43c4-89a5-db4cc20033db.gif)
